### PR TITLE
Revert "== to ===", allows comparison of string and integer

### DIFF
--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -85,7 +85,7 @@ $(document).ready(function() {
 
       // find the todo to update by its id
       var todoToUpdate = allTodos.filter(function (todo) {
-        return todo._id === todoId;
+        return todo._id == todoId;
       })[0];
 
       // serialze form data
@@ -115,7 +115,7 @@ $(document).ready(function() {
 
       // find the todo to delete by its id
       var todoToDelete = allTodos.filter(function (todo) {
-        return todo._id === todoId;
+        return todo._id == todoId;
       })[0];
 
       // DELETE request to delete todo


### PR DESCRIPTION
This reverts commit 8218ad9125d1873c92b22bbddc73ca790f660f3d.

I've added an issue to use `===` and explicit string coercion. See issue #SF_WDI_labs/11
